### PR TITLE
VAULT-85: Problem with swedish charset (utf-8) in subpath naming of s…

### DIFF
--- a/grails-app/init/vaulttool/Application.groovy
+++ b/grails-app/init/vaulttool/Application.groovy
@@ -24,9 +24,9 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware{
         println "### Start setting up Tomcat AJP on port 8009 and encoding attributes to UTF-8 ###"
         TomcatEmbeddedServletContainerFactory tomcat = new TomcatEmbeddedServletContainerFactory()
         tomcat.addAdditionalTomcatConnectors(createSslConnector())
-        HeaderEncodingValve headerEncodingValve = new HeaderEncodingValve()
-        headerEncodingValve.setPattern('^.*$')
-        tomcat.addContextValves(headerEncodingValve)
+        //HeaderEncodingValve headerEncodingValve = new HeaderEncodingValve()
+        //headerEncodingValve.setPattern('^.*$')
+        //tomcat.addContextValves(headerEncodingValve)
         println "### Finished setting up Tomcat AJP on port 8009 and encoding attributes to UTF-8 ###"
         return tomcat
     }


### PR DESCRIPTION
…ecret. Removed the old HeaderEncodingValve from embedded tomcat initialization.