### PR TITLE
VAULT-88: this version of springBoot includes embedded tomcat 9.x. In…

### DIFF
--- a/grails-app/conf/logback.groovy
+++ b/grails-app/conf/logback.groovy
@@ -50,7 +50,6 @@ if(Environment.isDevelopmentMode() || Environment.currentEnvironment == Environm
     logger("se.su.it.vaulttool", INFO, ['TIME_BASED_FILE', 'SYSLOG'], false)
     logger("groovyx.net.http.ParserRegistry", ERROR, ['TIME_BASED_FILE', 'SYSLOG'], false)
     logger("org.hibernate.orm.deprecation", ERROR, ['TIME_BASED_FILE', 'SYSLOG'], false)
-    logger("org.apache.coyote.ajp.AjpProcessor", DEBUG, ['TIME_BASED_FILE', 'SYSLOG'], false)
     println("### Finished setting up logback for production mode ###")
 }
 

--- a/grails-app/init/vaulttool/Application.groovy
+++ b/grails-app/init/vaulttool/Application.groovy
@@ -43,8 +43,7 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware{
             ajpConnector.setProperty("address", "127.0.0.1")
             ajpConnector.setProperty("enableLookups", "false")
             ajpConnector.URIEncoding = "UTF-8"
-            //ajpConnector.setProperty("address","0.0.0.0");
-            ajpConnector.setProperty("allowedRequestAttributesPattern",".*");
+            ajpConnector.setProperty("allowedRequestAttributesPattern",".*")
             ((AbstractAjpProtocol) ajpConnector.getProtocolHandler()).setSecretRequired(false)
             return ajpConnector
         } catch (Throwable ex) {


### PR DESCRIPTION
… tomcat 9 you need to specify allowedRequestAttributesPattern to be able to insert shib-attributes from apache to AJP.